### PR TITLE
Remove extra named export of Svg

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function createElement(name, type) {
 }
 
 const Svg = createElement("Svg", "svg");
-export default Svg;
+export default createElement("Svg", "svg");
 
 export const Circle = createElement("Circle", "circle");
 Svg.Circle = Circle;
@@ -99,7 +99,7 @@ Svg.Rect = Rect;
 export const Stop = createElement("Stop", "stop");
 Svg.Stop = Stop;
 
-export const Svg = createElement("Svg", "svg");
+export Svg;
 Svg.Svg = Svg;
 
 export const Symbol = createElement("Symbol", "symbol");

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ function createElement(name, type) {
 
 const Svg = createElement("Svg", "svg");
 export default Svg;
-Svg.Svg = Svg; // stay consistent with the old require based api
 
 export const Circle = createElement("Circle", "circle");
 Svg.Circle = Circle;


### PR DESCRIPTION
this is a fix for the following error

```
ERROR in ./node_modules/react-native-svg-web/index.js 103:13
Module parse failed: Identifier 'Svg' has already been declared (103:13)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| Svg.Stop = Stop;
| 
> export const Svg = createElement("Svg", "svg");
| Svg.Svg = Svg;
| 
```

This line was added in the recent PR:
```js
Svg.Svg = Svg; // stay consistent with the old require based api
```
but the author didn't realise that Svg was already a named export:
```js
Svg.Svg = createElement('Svg', 'svg');
```
This was then changed to this in that PR:
```js
export const Svg = createElement("Svg", "svg");
Svg.Svg = Svg;
```
But since Svg was already declared it throws an error