### PR TITLE
Fix create Element

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@
  * SOFTWARE.
  *
  */
-import { createElement as createReactElement } from "react";
+import { unstable_createElement as createReactElement } from "react";
 import PropTypes from "prop-types";
 
 function createElement(name, type) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "prop-types": "*",
     "react": "*",
-    "react-native-web": "*"
+    "react-native-web": "^0.12.2"
   },
   "devDependencies": {
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Since react-native-web 0.12, createElement has been renamed to unstable_createElement
An error has been reported (https://github.com/bakerface/react-native-svg-web/pull/3)

I also fixed the version of rn web, so things like this doesn't show up again