### PR TITLE
Use class component instead of stateless

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,21 +27,18 @@ import PropTypes from "prop-types";
 const createReactElement = ReactNativeWeb.unstable_createElement || React.createElement;
 
 function createElement(name, type) {
-  function CreateElement(props) {
-    return createReactElement(type, props, props.children);
+  return class CreateElement extends React.Component {
+    static displayName = name;
+    static propTypes = {
+      children: PropTypes.node,
+    };
+    static defaultProps = {
+      children: undefined,
+    };
+    render() {
+      return createReactElement(type, this.props, this.props.children);
+    }
   }
-
-  CreateElement.displayName = name;
-
-  CreateElement.propTypes = {
-    children: PropTypes.node,
-  };
-
-  CreateElement.defaultProps = {
-    children: undefined,
-  };
-
-  return CreateElement;
 }
 
 export const Svg = createElement("Svg", "svg");


### PR DESCRIPTION
Made it works with [`createAnimatedComponent`](https://github.com/necolas/react-native-web/blob/1ad16930391303da511c98879fa7b2002b28c822/packages/react-native-web/src/vendor/react-native/Animated/createAnimatedComponent.js#L21).

\* I got the `createAnimatedComponent ` error when I try to import [`react-native-chart-kit`](https://github.com/indiespirit/react-native-chart-kit/blob/master/src/line-chart/line-chart.js#L21) on web.

/cc @bakerface